### PR TITLE
Enabling comments toggle feature (default ctrl+/)

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Comments</string>
+  <key>scope</key>
+  <string>source.p4</string>
+  <key>settings</key>
+  <dict>
+    <key>shellVariables</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START</string>
+        <key>value</key>
+        <string>// </string>
+      </dict>
+    </array>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This creates `Comments.tmPreferences` files which dictactes what happens when executing the toggle comments command (by default is actived by pressing `ctrl+/`). It will either add `//` or remove `//` in front of the selected lines.