### PR TITLE
Fixed issue with removing block comments using the shortcut.

### DIFF
--- a/p4.YAML-tmLanguage
+++ b/p4.YAML-tmLanguage
@@ -41,7 +41,7 @@ repository:
     patterns:
     - name: comment.block.p4
       begin: \s*(/\*)
-      end: (\*/)(\n?)
+      end: (\*/)
     - name: comment.line.double.slash.p4
       begin: \s*(//)
       end: (?<=$\n)(?<!\\$\n)

--- a/p4.tmLanguage
+++ b/p4.tmLanguage
@@ -300,7 +300,7 @@ Todo:
 					<key>begin</key>
 					<string>\s*(/\*)</string>
 					<key>end</key>
-					<string>(\*/)(\n?)</string>
+					<string>\s*(\*/)</string>
 					<key>name</key>
 					<string>comment.block.p4</string>
 				</dict>


### PR DESCRIPTION
#5  Removed '(\n?)' from the end pattern of block comments.